### PR TITLE
Bump wayland and python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - name: Setup environment
         run: |
@@ -35,10 +35,10 @@ jobs:
       - name: Build wayland
         working-directory: wayland-${{ matrix.wayland-version }}
         run: |
-          ./configure --disable-documentation --prefix=/usr
-          make
-          DESTDIR=~/wayland make install
-          sudo make install
+          meson build --prefix=/usr -Ddocumentation=false
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          sudo ninja -C build install
       - name: Build wayland-protocols
         working-directory: wayland-protocols-${{ matrix.wayland-protocols-version }}
         run: |
@@ -60,9 +60,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3, "3.6", "3.7", "3.8", "3.9"]
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        python-version: ["pypy-3.7", "3.7", "3.8", "3.9", "3.10"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - uses: actions/checkout@v2
       - name: Download wayland libraries
@@ -109,9 +109,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        python-version: ["3.10"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - uses: actions/checkout@v2
       - name: Download wayland libraries
@@ -142,9 +142,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        python-version: ["3.10"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - uses: actions/checkout@v2
       - name: Download wayland libraries
@@ -175,9 +175,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        python-version: ["3.10"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - uses: actions/checkout@v2
       - name: Download wayland libraries
@@ -208,9 +208,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
-        wayland-version: ["1.19.0"]
-        wayland-protocols-version: ["1.23"]
+        python-version: ["3.10"]
+        wayland-version: ["1.20.0"]
+        wayland-protocols-version: ["1.24"]
     steps:
       - uses: actions/checkout@v2
       - name: Download wayland libraries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux_2_24_x86_64
     env:
-      wayland-version: "1.19.0"
-      wayland-protocols-version: "1.23"
+      wayland-version: "1.20.0"
+      wayland-protocols-version: "1.24"
     steps:
       - name: Install dependencies
         run: |
@@ -72,7 +72,7 @@ jobs:
     needs: build-wayland
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Download wayland libraries
         uses: actions/download-artifact@v2
@@ -148,7 +148,7 @@ jobs:
     needs: [build-wheel-cpython, build-wheel-pypy]
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
     steps:
       - name: Download wheels
         uses: actions/download-artifact@v2
@@ -171,7 +171,7 @@ jobs:
     container: quay.io/pypa/manylinux_2_24_x86_64
     needs: build-wayland
     env:
-      python-version: "3.9"
+      python-version: "3.10"
     steps:
       - name: Download wayland libraries
         uses: actions/download-artifact@v2
@@ -204,11 +204,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-wheel, build-source]
     steps:
-      - name: Download wheels CPython 3.6
-        uses: actions/download-artifact@v2
-        with:
-          name: wheels-3.6
-          path: dist/
       - name: Download wheels CPython 3.7
         uses: actions/download-artifact@v2
         with:
@@ -223,6 +218,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: wheels-3.9
+          path: dist/
+      - name: Download wheels CPython 3.10
+        uses: actions/download-artifact@v2
+        with:
+          name: wheels-3.10
           path: dist/
       - name: Download wheels PyPy 3.7
         uses: actions/download-artifact@v2

--- a/doc/protocol_build.py
+++ b/doc/protocol_build.py
@@ -2,8 +2,8 @@ import os
 import tarfile
 import urllib.request
 
-wayland_version = '1.18.0'
-protocols_version = '1.20'
+wayland_version = '1.20.0'
+protocols_version = '1.24'
 
 wayland_source = 'https://cgit.freedesktop.org/wayland/wayland/plain/protocol/wayland.xml?id={}'.format(wayland_version)
 protocols_source = 'https://wayland.freedesktop.org/releases/wayland-protocols-{}.tar.xz'.format(protocols_version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ classifiers =
   Operating System :: POSIX :: Linux
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Programming Language :: Python :: Implementation :: CPython
   Programming Language :: Python :: Implementation :: PyPy
   Topic :: Desktop Environment :: Window Managers
@@ -29,7 +29,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires >= 3.6
+python_requires >= 3.7
 setup_requires =
   cffi >= 1.12.0
 install_requires =
@@ -54,7 +54,7 @@ include =
 max-line-length = 120
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 disallow_subclassing_any = True
 no_implicit_optional = True
 show_error_codes = True


### PR DESCRIPTION
Update wayland / wayland protocols to 1.20 and 1.24, respectively.

Python 3.6 is EOL, so drop that. Add Python 3.10 to tested and released versions.