### PR TITLE
wl_list_remove leave wl_listener links invalid, not ffi.NULL

### DIFF
--- a/pywayland/server/client.py
+++ b/pywayland/server/client.py
@@ -103,7 +103,7 @@ class Client:
         :param listener: The listener object
         :type listener: :class:`~pywayland.server.Listener`
         """
-        assert self._ptr is not None
+        assert self._ptr is not None and listener._ptr is not None
         lib.wl_client_add_destroy_listener(self._ptr, listener._ptr)
 
     @ensure_valid

--- a/pywayland/server/listener.py
+++ b/pywayland/server/listener.py
@@ -62,16 +62,18 @@ class Listener:
         self.container = ffi.new("struct wl_listener_container *")  # type: ignore[assignment]
         self.container.handle = self._handle
 
-        self._ptr = ffi.addressof(self.container.destroy_listener)
+        self._ptr: ffi.ListenerCData | None = ffi.addressof(
+            self.container.destroy_listener
+        )
         self._ptr.notify = lib.notify_func
         self._notify = function
         self._signal = None
 
     def remove(self) -> None:
         """Remove the listener"""
-        if self._ptr.link != ffi.NULL:
+        if self._ptr and self._ptr.link != ffi.NULL:
             lib.wl_list_remove(ffi.addressof(self._ptr.link))
-            self.link = None
+            self._ptr = None
 
 
 class Signal:


### PR DESCRIPTION
A listener's link shouldn't be removed more than one time from the
signal's wl_list, but it can, and doing so leads to crashes. The
existing logic seems to imply that `wl_list_remove` leaves the link as a
NULL pointer, blocking subsequent removals. However, the Wayland docs
state "Note: This operation leaves elm [the link] in an invalid state.
" Instead of relying on that, we should set the object's pointer to
`None` and use that to block subsequent removals.

Also, the `self.link` attribute looks like forgotten code that should have been removed.