### PR TITLE
Log exceptions that are raised during callbacks

### DIFF
--- a/pywayland/server/listener.py
+++ b/pywayland/server/listener.py
@@ -14,10 +14,13 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Callable
 
 from pywayland import ffi, lib
 from pywayland.utils import wl_container_of
+
+logger = getLogger(__package__)
 
 
 # void (*wl_notify_func_t)(struct wl_listener *listener, void *data);
@@ -32,7 +35,11 @@ def notify_func(listener_ptr, data):
         data = listener._signal._data_wrapper(data)
 
     callback = listener._notify
-    callback(listener, data)
+
+    try:
+        callback(listener, data)
+    except Exception:
+        logger.exception("Exception in callback function")
 
 
 class Listener:


### PR DESCRIPTION
This instantiates a logger that is used by listeners to log exceptions
risen during callbacks, following emission of a signal. Currently there
is no means for callback exceptions to be monitored. This lets client
code configure the logger and redirect exception log messages where they
please.