### PR TITLE
Require setuptools>=62.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.0.0",
+    "setuptools>=62.4.0",
     "wheel",
     "cffi>=1.12.0; platform_python_implementation != 'PyPy'",
 ]


### PR DESCRIPTION
[`setuptools.command.build`](https://github.com/flacjacket/pywayland/blob/5a22c362ba380984e2c464b7757457fcaad0c6cc/setup.py#L20) was only introduced here:

https://github.com/pypa/setuptools/commits/v62.4.0/setuptools/command/build.py