### PR TITLE
Listener removes itself from Signal._link

### DIFF
--- a/pywayland/ffi_build.py
+++ b/pywayland/ffi_build.py
@@ -166,6 +166,7 @@ struct wl_signal {
     struct wl_list listener_list;
 };
 
+void wl_signal_init(struct wl_signal *signal);
 void wl_signal_add(struct wl_signal *signal, struct wl_listener *listener);
 void wl_signal_emit(struct wl_signal *signal, void *data);
 """

--- a/pywayland/server/listener.py
+++ b/pywayland/server/listener.py
@@ -77,9 +77,16 @@ class Listener:
         self._signal = None
 
     def remove(self) -> None:
-        """Remove the listener"""
+        """Remove the listener.
+
+        After removal the listener must not be used anymore.
+        """
         if self._ptr and self._ptr.link != ffi.NULL:
             lib.wl_list_remove(ffi.addressof(self._ptr.link))
+            assert self._signal
+            self._signal._link.remove(self)
+            self._signal = None
+            self._notify = None
             self._ptr = None
 
 
@@ -95,7 +102,7 @@ class Signal:
 
     def __init__(self, *, ptr=None, data_wrapper=None):
         if ptr is None:
-            self._ptr = ffi.new("struct wl_listener *")
+            self._ptr = ffi.new("struct wl_signal *")
             lib.wl_signal_init(self._ptr)
         else:
             self._ptr = ptr

--- a/test/test_issue_61.py
+++ b/test/test_issue_61.py
@@ -1,0 +1,32 @@
+"""
+Test against issue <https://github.com/flacjacket/pywayland/issues/61>
+"""
+
+from pywayland.server import Listener, Signal
+
+
+def test_ref_removal():
+
+    def callback(*_):
+        pass
+
+    sig = Signal()
+    listener = Listener(callback)
+    assert listener._ptr is not None
+    assert listener._notify is not None
+    assert listener._signal is None
+    assert not sig._link
+    sig.add(listener)
+    assert len(sig._link) == 1
+    assert listener._signal == sig
+    listener.remove()
+    assert len(sig._link) == 0
+    assert listener._signal is None
+    assert listener._notify is None
+    assert listener._ptr is None
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])


### PR DESCRIPTION
On removal Listener removes
* itself from Signal._link
* sets the reference to the signal to None
* sets the reference to the notify callback to None

Added test case for the issue.

Closes #61

Fixed Signal constructor with no pointer:
* self._ptr uses wl_signal instead of wl_listener
* Added wl_signal_init to ffibuild.

Closes #62