### PR TITLE
fix: move to pypy 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.10"
+          - "pypy-3.11"
         wayland-version: ["1.23.0"]
         wayland-protocols-version: ["1.36"]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         pypy-version: ["7.3"]
     steps:
       - name: Download wayland libraries
@@ -158,7 +158,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.10"
+          - "pypy-3.11"
     steps:
       - name: Download wheels
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- Mitigate zlib AttributeError problem (check [this commit](https://github.com/pypy/pypy/commit/e884ecc9d2c4ff7fd1bb797695d32f67d5d81348)).
- Soon 3.10 will be dropped (as stated "[In the next release we will drop 3.10](https://doc.pypy.org/en/latest/release-v7.3.19.html)" by pypy)