### PR TITLE
fix: use SPDX license expression, avoid deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install setuptools
+          pip install "setuptools>=77.0.0"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           python pywayland/ffi_build.py
@@ -138,7 +138,7 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install setuptools
+          pip install "setuptools>=77.0.0"
           pip install -r requirements.txt
           pip install -r doc/requirements.txt
           python pywayland/ffi_build.py
@@ -187,7 +187,7 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install setuptools
+          pip install "setuptools>=77.0.0"
           pip install -r requirements.txt
           pip install -r requirements-types.txt
           python pywayland/ffi_build.py
@@ -219,7 +219,7 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install setuptools
+          pip install "setuptools>=77.0.0"
           pip install -r requirements.txt
           pip install build check-manifest twine
           python pywayland/ffi_build.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=62.4.0",
+    "setuptools>=77.0.0",
     "wheel",
     "cffi>=1.12.0; platform_python_implementation != 'PyPy'",
 ]
@@ -11,14 +11,13 @@ name = "pywayland"
 description = "Python bindings for the libwayland library written in pure Python"
 authors = [{name = "Sean Vig", email = "sean.v.775@gmail.com"}]
 requires-python = ">=3.9"
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 readme = "README.rst"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
See warning:
```
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/usr/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```