### PR TITLE
Improve examples

### DIFF
--- a/example/color_manager.py
+++ b/example/color_manager.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025 Lubosz Sarnecki <lubosz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+from pywayland.client import Display
+from pywayland.protocol.wayland.wl_registry import WlRegistryProxy
+from pywayland.protocol.color_management_v1 import WpColorManagerV1
+from pywayland.protocol.color_management_v1.wp_color_manager_v1 import WpColorManagerV1Proxy
+
+
+class App:
+    def __init__(self):
+        self.color_manager = None
+        self.render_intents = []
+        self.features = []
+        self.transfer_functions = []
+        self.primaries = []
+
+
+def color_manager_supported_intent_cb(color_manager: WpColorManagerV1Proxy, render_intent: int):
+    app = color_manager.user_data
+    app.render_intents.append(WpColorManagerV1.render_intent(render_intent))
+
+def color_manager_supported_feature_cb(color_manager: WpColorManagerV1Proxy, feature: int):
+    app = color_manager.user_data
+    app.features.append(WpColorManagerV1.feature(feature))
+
+def color_manager_supported_tf_named_cb(color_manager: WpColorManagerV1Proxy, transfer_function: int):
+    app = color_manager.user_data
+    app.transfer_functions.append(WpColorManagerV1.transfer_function(transfer_function))
+
+def color_manager_supported_primaries_named_cb(color_manager: WpColorManagerV1Proxy, primaries: int):
+    app = color_manager.user_data
+    app.primaries.append(WpColorManagerV1.primaries(primaries))
+
+def color_manager_done_cb(color_manager: WpColorManagerV1Proxy):
+    app = color_manager.user_data
+
+    print(f"Render intents ({len(app.render_intents)})")
+    for render_intent in app.render_intents:
+        print(f"\t{render_intent.name}")
+
+    print(f"Features ({len(app.features)})")
+    for feature in app.features:
+        print(f"\t{feature.name}")
+
+    print(f"Transfer Functions ({len(app.transfer_functions)})")
+    for transfer_function in app.transfer_functions:
+        print(f"\t{transfer_function.name}")
+
+    print(f"Primaries ({len(app.primaries)})")
+    for primaries in app.primaries:
+        print(f"\t{primaries.name}")
+
+
+def registry_global_cb(registry: WlRegistryProxy, name: int, interface: str, version: int):
+    app = registry.user_data
+    if interface == "wp_color_manager_v1":
+        app.color_manager = registry.bind(name, WpColorManagerV1, version)
+        app.color_manager.dispatcher["supported_intent"] = color_manager_supported_intent_cb
+        app.color_manager.dispatcher["supported_feature"] = color_manager_supported_feature_cb
+        app.color_manager.dispatcher["supported_tf_named"] = color_manager_supported_tf_named_cb
+        app.color_manager.dispatcher["supported_primaries_named"] = color_manager_supported_primaries_named_cb
+        app.color_manager.dispatcher["done"] = color_manager_done_cb
+        app.color_manager.user_data = app
+
+def main():
+    app = App()
+
+    display = Display()
+    display.connect()
+
+    registry = display.get_registry()
+    registry.dispatcher["global"] = registry_global_cb
+    registry.user_data = app
+
+    display.dispatch(block=True)
+    display.roundtrip()
+
+    if app.color_manager is None:
+        print("Compositor does not provide wp_color_manager_v1")
+
+    display.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/example/surface.py
+++ b/example/surface.py
@@ -53,15 +53,8 @@ def shell_surface_ping_handler(shell_surface, serial):
 
 
 def shm_format_handler(shm, format_):
-    if format_ == WlShm.format.argb8888.value:
-        s = "ARGB8888"
-    elif format_ == WlShm.format.xrgb8888.value:
-        s = "XRGB8888"
-    elif format_ == WlShm.format.rgb565.value:
-        s = "RGB565"
-    else:
-        s = "other format"
-    print(f"Possible shmem format: {s}")
+    format_enum = WlShm.format(format_)
+    print(f"Possible shmem format: {format_enum.name}")
 
 
 def registry_global_handler(registry, id_, interface, version):


### PR DESCRIPTION
This series adds support for the `xdg_shell` protocol in the examples, making it run on GNOME Shell and other window managers that do not expose the `wl_shell` protocol.
It also showcases how to use extra protocols.
In addition the example now is able to print all available shm format names by using the available enum.

Furthermore I have added an example that uses the `color_management_v1` protocol to further showcase usage of protocols. This will avoid confusion that arises in issues like #68 since `pywayland` is very well capable of calling protocols.

For protocol support I didn't need to do anything besides having the `wayland-protocols` package installed.
But calling `python -m pywayland.scanner --with-protocols` might be required to update the registry if it has been build without `wayland-protocols` installed.