### PR TITLE
Fix: remove default args in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,12 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install .[ci]
+          pip install -e .[ci]
           python pywayland/ffi_build.py
           python -m pywayland.scanner --with-protocols
       - name: Run unit tests
         run: |
-          pip install .[test]
+          pip install -e .[test]
           pytest --cov pywayland --cov-report term-missing
       - name: Push coverage
         run: coveralls --service=github
@@ -139,12 +139,12 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install .[ci]
+          pip install -e .[ci]
           python pywayland/ffi_build.py
           python -m pywayland.scanner --with-protocols
       - name: Build docs
         run: |
-          pip install .[docs]
+          pip install -e .[docs]
           sphinx-build -W -b html doc doc/_build/html
   pre-commit-test:
     name: pre-commit test
@@ -171,7 +171,7 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install .[ci]
+          pip install -e .[ci]
           python pywayland/ffi_build.py
           python -m pywayland.scanner --with-protocols
       - name: Run pre-commit test
@@ -201,12 +201,12 @@ jobs:
           echo "XDG_RUNTIME_DIR=/tmp" >> $GITHUB_ENV
       - name: Install Python dependencies
         run: |
-          pip install .[ci]
+          pip install -e .[ci]
           python pywayland/ffi_build.py
           python -m pywayland.scanner --with-protocols
       - name: Run packaging test
         run: |
-          pip install .[packaging]
+          pip install -e .[packaging]
           check-manifest
           python setup.py check -m -s
           python -m build --sdist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,5 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
+        args: []
         files: "^(pywayland|example)\/.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ ci = ["setuptools>=77.0.0"]
 test = [
     "pytest",
     "pytest-cov",
-    "coverage>=6.5.0",
-    "coveralls>=3.3.1",
+    "coverage>=7.13.0",
+    "coveralls>=4.0.2",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
These are just minor improvements to conform with https://github.com/flacjacket/pywlroots/pull/245 changes I added in the other repo.

Plus, it prevents the injection of default arguments in `mypy` by emptying the array.